### PR TITLE
Fixes navigation bar scaling issues, including logo and menu button.

### DIFF
--- a/source/components/home/navigation/styles.scss
+++ b/source/components/home/navigation/styles.scss
@@ -33,8 +33,10 @@
     &__logo {
         width: 7.5vh !important;
         position: absolute;
-        top: 50%;
-        transform: translateY(-50%) !important;
+        transform: translateY(-17%) !important;
+    }
+    button.collapsed {
+        transform: translateY(27%) !important;
     }
 }
 
@@ -56,12 +58,6 @@
             font-size: 1.4em!important;
         }
     }
-    .Navigation__logo {
-        transform: translateY(-50%) !important;
-    }
-    button.collapsed {
-        transform: translateY(30%) !important;
-    }
 }
 
 @media (max-width: 750px) {
@@ -74,11 +70,6 @@
     }
     .Navigation__logo {
         position: relative;
-        top: 13px !important;
-        transform: translateY(-25%) !important;
-    }
-    button.collapsed {
-        transform: translateY(67%) !important;
     }
     .Navigation {
         .navbar {
@@ -86,23 +77,5 @@
                 font-size: 1em;
             }
         }
-    }
-}
-
-@media (max-width: 600px) {
-    .Navigation__logo {
-        transform: translateY(-25%) !important;
-    }
-    button.collapsed {
-        transform: translateY(67%) !important;
-    }
-}
-
-@media (max-width: 350px) {
-    .Navigation__logo {
-        transform: translateY(-16.67%) !important;
-    }
-    button.collapsed {
-        transform: translateY(50%) !important;
     }
 }


### PR DESCRIPTION
The bar always contains both items, with sufficient top+bottom padding.
Addresses #78 

## Screenshots:
![image](https://user-images.githubusercontent.com/13492296/43997567-e62c672e-9dac-11e8-89fa-7cb7781472a1.png)
![image](https://user-images.githubusercontent.com/13492296/43997568-eb3f1ba8-9dac-11e8-8d62-a886a72338ed.png)