### PR TITLE
Addded OAuth flow for scanner apps.

### DIFF
--- a/source/components/auth/scanAuth.scss
+++ b/source/components/auth/scanAuth.scss
@@ -1,0 +1,36 @@
+$background-color: rgba(204, 217, 252, 0);
+
+#app,
+[data-reactroot],
+body,
+html {
+    height: 100vh;
+}
+
+.background {
+    z-index: 100;
+    width: 1000vw;
+    height: 1000vh;
+    background-color: #28323f;
+}
+
+.registerContainer {
+    //background-color: rgba(256, 256, 256, 0.0);
+    background-color: #28323f;
+    //background: linear-gradient(#28323f, #97c88c);
+    width: 100%;
+    height: 100vh;
+    padding: 10em !important;
+    //background-color: $background-color;
+    overflow: auto;
+    @media only screen and (max-width: 1200px) {
+        padding: 6em !important;
+    }
+    @media only screen and (max-width: 640px) {
+        padding: 1em !important;
+    }
+}
+
+h1 {
+    color: white;
+}

--- a/source/index.jsx
+++ b/source/index.jsx
@@ -7,6 +7,7 @@ import Home from './components/home/home';
 import Landing from './components/landing/landing';
 import Register from './components/register/register';
 import Auth from './components/auth/auth';
+import ScanAuth from './components/auth/scanAuth';
 import RegisterStart from './components/registerStart/registerStart';
 import RegisterSuccess from './components/registerSuccess/registerSuccess';
 import PuzzleBang from './components/puzzlebang/puzzlebang';
@@ -70,7 +71,11 @@ render(
             <Route exact path="/start" component={RegisterStart}/>
             <Route exact path="/registersuccess" component={RegisterSuccess}/>
             <Route exact path="/register" component={Register}/>
+            // For registration flow auth
             <Route exact path="/auth" component={Auth}/>
+            // For scanning app flow auth
+            <Route exact path="/scanAuth" component={ScanAuth}/>
+
         </div>
     </BrowserRouter>,
     document.getElementById('app')


### PR DESCRIPTION
If the origin of the request to {website}/auth has isMobile query parameter set, a redirect is issued to an `acmrp://auth?token={JWT}` URI via `https://reflectionsprojections.org/scanAuth`, which trades OAuth authorization codes for token(internally handled by the API) and most importantly, the API JWT.